### PR TITLE
헤더 오른쪽 뱃지 개발

### DIFF
--- a/app/components/header/DefaultHeaderRight.tsx
+++ b/app/components/header/DefaultHeaderRight.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {Image, TouchableOpacity, Text} from 'react-native';
+import {useNavigation, useRoute} from '@react-navigation/native';
+import styles from './styles';
+
+const defaultHeaderRight = (): JSX.Element => {
+  const navigation = useNavigation<any>();
+  const route = useRoute();
+  return (
+    <TouchableOpacity
+        onPress={() => {}}
+        style={styles.defaultHeaderRightContainer}>
+        <Image
+            source={require('../../assets/images/profile_image_sample.png')}
+            style={styles.headerProfileIcon}
+        />
+        <Text style={styles.headerProfileName}>홍진경</Text>
+      
+    </TouchableOpacity>
+  );
+};
+
+export default defaultHeaderRight;

--- a/app/components/header/DefaultHeaderRight.tsx
+++ b/app/components/header/DefaultHeaderRight.tsx
@@ -3,7 +3,16 @@ import {Image, TouchableOpacity, Text} from 'react-native';
 import {useNavigation, useRoute} from '@react-navigation/native';
 import styles from './styles';
 
-const defaultHeaderRight = (): JSX.Element => {
+type Props = {
+  imageURL: string;
+  characterName: string;
+
+};
+
+const DefaultHeaderRight = ({
+  imageURL,
+  characterName
+}: Props): JSX.Element => {
   const navigation = useNavigation<any>();
   const route = useRoute();
   return (
@@ -11,13 +20,13 @@ const defaultHeaderRight = (): JSX.Element => {
         onPress={() => {}}
         style={styles.defaultHeaderRightContainer}>
         <Image
-            source={require('../../assets/images/profile_image_sample.png')}
+            source={{uri : imageURL}}
             style={styles.headerProfileIcon}
         />
-        <Text style={styles.headerProfileName}>홍진경</Text>
+        <Text style={styles.headerProfileName}>{characterName}</Text>
       
     </TouchableOpacity>
   );
 };
 
-export default defaultHeaderRight;
+export default DefaultHeaderRight;

--- a/app/components/header/styles.tsx
+++ b/app/components/header/styles.tsx
@@ -4,4 +4,27 @@ export default StyleSheet.create({
   writingRightText: {
     color: '#55A5FD',
   },
+
+  defaultHeaderRightContainer: {
+    flexDirection: 'row',
+    height: 32,
+    backgroundColor: '#171C2E',
+    borderRadius: 30,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingRight: 9,
+  },
+
+  headerProfileIcon: {
+    width: 32,
+    height: 32,
+  },
+
+  headerProfileName: {
+    fontFamily: 'Pretend Regular',
+    fontWeight:'bold',
+    fontSize: 12,
+    color: '#FFFFFF',
+    marginLeft: 4,
+  },
 });

--- a/app/routes/home-tab/HomeTabRootNavigator.tsx
+++ b/app/routes/home-tab/HomeTabRootNavigator.tsx
@@ -5,6 +5,7 @@ import styles from '../styles';
 import Home from '../../pages/Home/Home';
 import Profile from '../../pages/Profile/Profile';
 import DefaultHeaderLeft from '../../components/header/DefaultHeaderLeft';
+import DefaultHeaderRight from '../../components/header/DefaultHeaderRight';
 import PuzzleWritingQuestion from '../../pages/PuzzleWritingQuestion/PuzzleWritingQuestion';
 import WritingHeaderLeft from '../../components/header/WritingHeaderLeft';
 import WritingHeaderRight from '../../components/header/WritingHeaderRight';
@@ -56,6 +57,7 @@ const HomeTabRootNavigator = (): JSX.Element => {
             ),
           headerLeft: () => <DefaultHeaderLeft />,
           title: '',
+          headerRight: () => <DefaultHeaderRight />,
         }}
       />
       <BottomTab.Screen

--- a/app/routes/home-tab/HomeTabRootNavigator.tsx
+++ b/app/routes/home-tab/HomeTabRootNavigator.tsx
@@ -57,7 +57,9 @@ const HomeTabRootNavigator = (): JSX.Element => {
             ),
           headerLeft: () => <DefaultHeaderLeft />,
           title: '',
-          headerRight: () => <DefaultHeaderRight />,
+          headerRight: () => (
+            <DefaultHeaderRight imageURL="../../assets/images/profile_image_sample.png" characterName="김영옥"/>
+          ), 
         }}
       />
       <BottomTab.Screen


### PR DESCRIPTION
## Ticket

https://itmca-harmony.atlassian.net/browse/HARMONY-19

## Description

피그마에서는 프로필 이미지와 남색 뱃지 사이의 틈이 존재하는데 , 
제가 만든 뱃지는 남색 뱃지의 왼쪽 코너와 프로필 이미지의 곡률이 딱 맞아떨어지도록 했습니다.

## Check Points

어떤 부분을 위주로 봐야 하는지 적어주세요.

## Checklist:
- [ ] 기존 코드 컨벤션(파일 이름 및 위치, 변수 이름 등)과 부합하는 코드를 작성했습니다.
- [ ] KISS, DRY, YAGNI 원칙을 지켰습니다.
- [ ] 이번 변경으로 인한 사이드이펙트를 충분히 고려하였습니다.
- [ ] Android, iOS 모두 정상 동작하는 것을 확인하였습니다.
- [ ] 이번 변경에 대한 테스트를 추가했습니다.
- [ ] 이번 변경 사항은 문서 변경을 필요로 합니다.
    - [ ] 필요한 문서 업데이트를 완료하였습니다.

## Reviewers:
- [ ] @그룹장
- [ ] @그 외 1명
