### PR TITLE
날짜 입력하는 부분 date picker 적용시키기

### DIFF
--- a/app/pages/AccountModification/AccountModification.tsx
+++ b/app/pages/AccountModification/AccountModification.tsx
@@ -6,6 +6,8 @@ import ColoredButton from '../../components/button/ColoredButton';
 import BouncyCheckbox from 'react-native-bouncy-checkbox';
 
 const AccountModification = (): JSX.Element => {
+  const [inputDate, setInputDate] = React.useState<Date | undefined>(undefined);
+
   return (
     <View style={styles.mainContainer}>
       <ScrollView
@@ -33,14 +35,23 @@ const AccountModification = (): JSX.Element => {
           value={''}
           placeholder="멋쟁이"
         />
-        <TextInput
+        {/* <TextInput
           style={styles.formInput}
           mode="outlined"
           secureTextEntry={true}
           label="태어난 날"
           value={''}
           placeholder="user@domain.com"
-        />
+        /> */}
+        <DatePickerInput
+          style={styles.dateInput}
+          locale="en"
+          label="태어난 날"
+          value={inputDate}
+          onChange={(d) => setInputDate(d)}
+          inputMode="start"
+          mode="outlined"
+        /> 
         <ColoredButton text="저장" onPress={() => {
 
         }} />

--- a/app/pages/AccountModification/styles.ts
+++ b/app/pages/AccountModification/styles.ts
@@ -27,6 +27,10 @@ export const styles = StyleSheet.create({
     width: '100%',
     marginBottom: 8,
   },
+  dateInput: {
+    width: '100%',
+    marginBottom: 0,
+  },
   formVerificationPartContainer: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/app/pages/CharacterModification/CharacterModification.tsx
+++ b/app/pages/CharacterModification/CharacterModification.tsx
@@ -4,8 +4,12 @@ import {styles} from './styles';
 import {TextInput} from 'react-native-paper';
 import ColoredButton from '../../components/button/ColoredButton';
 import BouncyCheckbox from 'react-native-bouncy-checkbox';
+import { DatePickerInput } from 'react-native-paper-dates';
+
 
 const CharacterModification = (): JSX.Element => {
+  const [inputDate, setInputDate] = React.useState<Date | undefined>(undefined);
+
   return (
     <View style={styles.mainContainer}>
       <ScrollView
@@ -25,14 +29,23 @@ const CharacterModification = (): JSX.Element => {
             value={''}
             placeholder="소중한 당신"
           />
-          <TextInput
+          {/* <TextInput
             style={styles.formInput}
             mode="outlined"
             secureTextEntry={true}
             label="태어난 날"
             value={''}
             placeholder="user@domain.com"
-          />
+          /> */}
+          <DatePickerInput
+            style={styles.dateInput}
+            locale="en"
+            label="태어난 날"
+            value={inputDate}
+            onChange={(d) => setInputDate(d)}
+            inputMode="start"
+            mode="outlined"
+          /> 
           <TextInput
             style={styles.formInput}
             mode="outlined"

--- a/app/pages/CharacterModification/styles.ts
+++ b/app/pages/CharacterModification/styles.ts
@@ -27,6 +27,10 @@ export const styles = StyleSheet.create({
     width: '100%',
     marginBottom: 8,
   },
+  dateInput: {
+    width: '100%',
+    marginBottom: 0,
+  },
   formVerificationPartContainer: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/app/pages/CharacterRegister/CharacterRegister.tsx
+++ b/app/pages/CharacterRegister/CharacterRegister.tsx
@@ -4,8 +4,12 @@ import {styles} from './styles';
 import {TextInput} from 'react-native-paper';
 import ColoredButton from '../../components/button/ColoredButton';
 import BouncyCheckbox from 'react-native-bouncy-checkbox';
+import { DatePickerInput } from 'react-native-paper-dates';
+
 
 const CharacterRegister = (): JSX.Element => {
+  const [inputDate, setInputDate] = React.useState<Date | undefined>(undefined);
+
   return (
     <View style={styles.mainContainer}>
       <ScrollView
@@ -25,13 +29,14 @@ const CharacterRegister = (): JSX.Element => {
           value={''}
           placeholder="소중한 당신"
         />
-        <TextInput
-          style={styles.formInput}
-          mode="outlined"
-          secureTextEntry={true}
-          label="태어난 날"
-          value={''}
-          placeholder="user@domain.com"
+        <DatePickerInput
+            style={styles.dateInput}
+            locale="en"
+            label="태어난 날"
+            value={inputDate}
+            onChange={(d) => setInputDate(d)}
+            inputMode="start"
+            mode="outlined"
         />
         <TextInput
           style={styles.formInput}

--- a/app/pages/CharacterRegister/styles.ts
+++ b/app/pages/CharacterRegister/styles.ts
@@ -27,6 +27,10 @@ export const styles = StyleSheet.create({
     width: '100%',
     marginBottom: 8,
   },
+  dateInput: {
+    width: '100%',
+    marginBottom: 0,
+  },
   socialContainer: {
     alignItems: 'center',
     justifyContent: 'flex-start',

--- a/app/pages/Register/Register.tsx
+++ b/app/pages/Register/Register.tsx
@@ -8,7 +8,7 @@ import { DatePickerInput } from 'react-native-paper-dates';
 
 
 const Register = ({navigation}): JSX.Element => {
-  const [inputDate, setInputDate] = React.useState<Date | undefined>(undefined)
+  const [inputDate, setInputDate] = React.useState<Date | undefined>(undefined);
   
   return (
     <View style={styles.mainContainer}>

--- a/app/pages/Register/Register.tsx
+++ b/app/pages/Register/Register.tsx
@@ -4,8 +4,12 @@ import {styles} from './styles';
 import {TextInput} from 'react-native-paper';
 import ColoredButton from '../../components/button/ColoredButton';
 import BouncyCheckbox from 'react-native-bouncy-checkbox';
+import { DatePickerInput } from 'react-native-paper-dates';
+
 
 const Register = ({navigation}): JSX.Element => {
+  const [inputDate, setInputDate] = React.useState<Date | undefined>(undefined)
+  
   return (
     <View style={styles.mainContainer}>
       <ScrollView
@@ -64,13 +68,14 @@ const Register = ({navigation}): JSX.Element => {
           value={''}
           placeholder="user@domain.com"
         />
-        <TextInput
-          style={styles.formInput}
-          mode="outlined"
-          secureTextEntry={true}
-          label="태어난 날"
-          value={''}
-          placeholder="user@domain.com"
+        <DatePickerInput
+            style={styles.dateInput}
+            locale="en"
+            label="태어난 날"
+            value={inputDate}
+            onChange={(d) => setInputDate(d)}
+            inputMode="start"
+            mode="outlined"
         />
         <TouchableOpacity
           style={{

--- a/app/pages/Register/styles.ts
+++ b/app/pages/Register/styles.ts
@@ -34,6 +34,10 @@ export const styles = StyleSheet.create({
     width: '100%',
     marginBottom: 8,
   },
+  dateInput: {
+    width: '100%',
+    marginBottom: 0,
+  },
   formVerificationPartContainer: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/index.js
+++ b/index.js
@@ -5,5 +5,7 @@
 import {AppRegistry} from 'react-native';
 import {name as appName} from './app.json';
 import index from './app/index';
+import {en, registerTranslation,} from 'react-native-paper-dates';
 
 AppRegistry.registerComponent(appName, () => index);
+registerTranslation('en', en);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-native-iphone-x-helper": "^1.3.1",
     "react-native-keyboard-accessory": "^0.1.15",
     "react-native-paper": "^4.12.0",
+    "react-native-paper-dates": "^0.8.7",
     "react-native-reanimated": "^2.5.0",
     "react-native-safe-area-context": "^3.3.2",
     "react-native-screens": "^3.8.0",


### PR DESCRIPTION
## Ticket

https://itmca-harmony.atlassian.net/browse/HARMONY-57

## Description
* react-native-paper-dates 라이브러리 설치 및 기본세팅
* "태어난 날" 부분 Text 입력에서 Date picker 입력으로 변경

## Check Points
1. localized 수정 필요
해당 라이브러리에 한국 기준이 없어서 en 버전으로 적용시켰습니다. 라이브러리에 PR을 남겨서 한국 버전을 만드는 작업 후 -> localized setting 을 한국으로 변경해야 할 필요가 있습니다.
2. date picker Input 박스 Bottom 여백 수정 필요
: 라이브러리 내장된 스타일이 자동적용 되어 있습니다. 어떻게 해야 할지 몰라서 일단 현재 작업까지 PR 날립니다.

## Checklist:
- [ ] 기존 코드 컨벤션(파일 이름 및 위치, 변수 이름 등)과 부합하는 코드를 작성했습니다.
- [ ] KISS, DRY, YAGNI 원칙을 지켰습니다.
- [ ] 이번 변경으로 인한 사이드이펙트를 충분히 고려하였습니다.
- [ ] Android, iOS 모두 정상 동작하는 것을 확인하였습니다.
- [ ] 이번 변경에 대한 테스트를 추가했습니다.
- [ ] 이번 변경 사항은 문서 변경을 필요로 합니다.
    - [ ] 필요한 문서 업데이트를 완료하였습니다.

## Reviewers:
- [ ] @그룹장
- [ ] @그 외 1명
